### PR TITLE
Resolve #9: Add early APIs for filtered contest generators

### DIFF
--- a/StubBackend/BackendServer.cpp
+++ b/StubBackend/BackendServer.cpp
@@ -34,6 +34,12 @@ BackendServer::BackendServer()
     return kj::READY_NOW;
 }
 
+::kj::Promise<void> BackendServer::searchContests(Backend::Server::SearchContestsContext context)
+{
+    context.getResults().setGenerator(kj::heap<ContestGeneratorImpl>());
+    return kj::READY_NOW;
+}
+
 ::kj::Promise<void> BackendServer::getContestResults(Backend::Server::GetContestResultsContext context)
 {
     auto contestId = context.getParams().getContestId()[0];

--- a/StubBackend/BackendServer.hpp
+++ b/StubBackend/BackendServer.hpp
@@ -37,6 +37,7 @@ public:
     // Backend::Server interface
 protected:
     virtual ::kj::Promise<void> getContestGenerator(GetContestGeneratorContext context);
+    virtual ::kj::Promise<void> searchContests(SearchContestsContext context);
     virtual ::kj::Promise<void> getContestResults(GetContestResultsContext context);
     virtual ::kj::Promise<void> purchaseResultReport(PurchaseResultReportContext context);
     virtual ::kj::Promise<void> downloadResultReport(DownloadResultReportContext context);

--- a/VotingApp/BackendWrapper.cpp
+++ b/VotingApp/BackendWrapper.cpp
@@ -42,4 +42,26 @@ ContestGeneratorWrapper* BackendWrapper::getFeedGenerator()
     return new ContestGeneratorWrapper(backend.getContestGeneratorRequest().send().getGenerator(), promiseConverter);
 }
 
+ContestGeneratorWrapper* BackendWrapper::getContestsByCreator(QString creator)
+{
+    auto request = backend.searchContestsRequest();
+    auto filters = request.initFilters(1);
+    filters[0].setType(Backend::Filter::Type::CONTEST_CREATOR);
+    auto arguments = filters[0].initArguments(1);
+    arguments.set(0, creator.toStdString());
+
+    return new ContestGeneratorWrapper(request.send().getGenerator(), promiseConverter);
+}
+
+ContestGeneratorWrapper* BackendWrapper::getContestsByCoin(quint64 coinId)
+{
+    auto request = backend.searchContestsRequest();
+    auto filters = request.initFilters(1);
+    filters[0].setType(Backend::Filter::Type::CONTEST_COIN);
+    auto arguments = filters[0].initArguments(1);
+    arguments.set(0, std::to_string(coinId));
+
+    return new ContestGeneratorWrapper(request.send().getGenerator(), promiseConverter);
+}
+
 } // namespace swv

--- a/VotingApp/BackendWrapper.hpp
+++ b/VotingApp/BackendWrapper.hpp
@@ -49,6 +49,8 @@ public:
     virtual ~BackendWrapper() noexcept {}
 
     Q_INVOKABLE swv::ContestGeneratorWrapper* getFeedGenerator();
+    Q_INVOKABLE swv::ContestGeneratorWrapper* getContestsByCreator(QString creator);
+    Q_INVOKABLE swv::ContestGeneratorWrapper* getContestsByCoin(quint64 coinId);
 
 private:
     PromiseConverter& promiseConverter;

--- a/shared/capnp/backend.capnp
+++ b/shared/capnp/backend.capnp
@@ -26,6 +26,8 @@ interface Backend {
 
     getContestGenerator @0 () -> (generator :ContestGenerator);
     # Get a generator for a feed of contests
+    searchContests @8 (filters :List(Filter)) -> (generator :ContestGenerator);
+    # Search contests and get a generator for the results
     getContestResults @1 (contestId :Data) -> (results :ContestResults);
     # Get the instantaneous live results for the specified contest
 
@@ -52,6 +54,20 @@ interface Backend {
         struct TalliedOpinion {
             contestant @0 :Int32;
             tally @1 :Int64;
+        }
+    }
+
+    struct Filter {
+        type @0 :Type;
+        arguments @1 :List(Text);
+
+        enum Type {
+            searchTerms @0;
+            # Search for contests containing the specified search terms. Each search term is an argument
+            contestCreator @1;
+            # Search for contests created by the specified account. Argument is a blockchain-specific account ID
+            contestCoin @2;
+            # Search for contests weighted by the specified coin. Argument is base-10 string of coin ID
         }
     }
 }


### PR DESCRIPTION
Eventually, we may want to refactor this to have the QML construct the
filters to expose maximum flexibility to the GUI; however, this is much
more elaborate and isn't needed for MVP.

Also, it may be desirable to have the server do something more
intelligent when 'searching' contests than just return the same list as
the feed returns; however, this could also be postponed until making a
real blockchain-based implementation (why waste so much effort creating
an elaborate stub?)
