### PR TITLE
Progress #78: Change VotingSystem::currentAccount from name to object

### DIFF
--- a/VotingApp/VotingSystem.hpp
+++ b/VotingApp/VotingSystem.hpp
@@ -63,7 +63,7 @@ class VotingSystemPrivate;
 class VotingSystem : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QString currentAccount READ currentAccount WRITE setCurrentAccount NOTIFY currentAccountChanged)
+    Q_PROPERTY(swv::data::Account* currentAccount READ currentAccount WRITE setCurrentAccount NOTIFY currentAccountChanged)
     Q_PROPERTY(QString lastError READ lastError NOTIFY error)
     Q_PROPERTY(bool isReady READ isReady NOTIFY isReadyChanged)
     Q_PROPERTY(bool isBackendConnected READ backendConnected NOTIFY backendConnectedChanged)
@@ -87,7 +87,7 @@ public:
     ChainAdaptorWrapper* adaptor();
     BackendWrapper* backend();
 
-    QString currentAccount() const;
+    swv::data::Account* currentAccount() const;
 
     /**
      * @brief Connect to the backend at the specified network endpoint
@@ -114,13 +114,15 @@ public:
     Q_INVOKABLE CoinWrapper* getCoin(quint64 id);
     Q_INVOKABLE CoinWrapper* getCoin(QString name);
 
+    Q_INVOKABLE swv::data::Account* getAccount(QString name);
+
 signals:
     void error(QString message);
     void isReadyChanged();
     void ready();
     void backendConnectedChanged(bool backendConnected);
     void adaptorReadyChanged(bool adaptorReady);
-    void currentAccountChanged(QString currentAccount);
+    void currentAccountChanged(swv::data::Account* currentAccount);
 
 public slots:
     void configureChainAdaptor();
@@ -134,7 +136,7 @@ public slots:
      */
     void cancelCurrentDecision(swv::ContestWrapper* contest);
 
-    void setCurrentAccount(QString currentAccount);
+    void setCurrentAccount(swv::data::Account* currentAccount);
 
 protected slots:
     void setLastError(QString message);

--- a/VotingApp/qml/SettingsPage.qml
+++ b/VotingApp/qml/SettingsPage.qml
@@ -35,10 +35,11 @@ ListPage {
             anchors.fill: parent
             model: votingSystem.myAccounts
             delegate: SimpleRow {
-                text: model.name
-                active: votingSystem.currentAccount === model.name
+                property Account account: votingSystem.myAccounts.get(index)
+                text: account.name
+                active: votingSystem.currentAccount === account
                 onSelected: {
-                    votingSystem.currentAccount = model.name
+                    votingSystem.currentAccount = account
                     accountSelector.close()
                 }
             }

--- a/VotingApp/qml/main.qml
+++ b/VotingApp/qml/main.qml
@@ -47,7 +47,6 @@ App {
 
     Settings {
         id: appSettings
-        property alias currentAccount: _votingSystem.currentAccount
         property alias windowX: window.x
         property alias windowY: window.y
         property alias windowHeight: window.height
@@ -68,14 +67,8 @@ App {
        }
        onIsReadyChanged: {
            console.log("Voting System Ready: " + isReady)
-           if (isReady && !currentAccount) {
-               currentAccount = Qt.binding(function() {
-                   if (adaptor.myAccounts.length)
-                       currentAccount = adaptor.myAccounts[0]
-               })
-           }
        }
-       onCurrentAccountChanged: console.log("Current account set to " + currentAccount)
+       onCurrentAccountChanged: console.log("Current account set to " + currentAccount.name)
     }
 
     Component {


### PR DESCRIPTION
Now the currentAccount property stores an Account object instead of just
an account name. Also, VotingSystem persists the current account
internally now instead of relying on QML to do that for it.
