### PR TITLE
Resolve #148

### DIFF
--- a/VotingApp/Apis/ContestResultsApi.cpp
+++ b/VotingApp/Apis/ContestResultsApi.cpp
@@ -8,6 +8,9 @@
 namespace swv {
 
 void ContestResultsApi::updateBarSeries(capnp::List<Backend::ContestResults::TalliedOpinion>::Reader talliedOpinions) {
+    if (m_results == nullptr)
+        return;
+
     std::vector<std::pair<QString, int64_t>> writeInResults;
     std::vector<int64_t> contestantResults(contest.get_contestants().size());
 
@@ -66,19 +69,22 @@ ContestResultsApi::ContestResultsApi(Backend::ContestResults::Client resultsApi,
 ContestResultsApi::~ContestResultsApi() noexcept {}
 
 void ContestResultsApi::setResults(QtCharts::QBarSeries* results) {
-    if (results == m_results || results == nullptr)
+    if (results == m_results)
         return;
 
-    results->clear();
-    auto sets = m_results->barSets();
+    if (results) {
+        results->clear();
+        auto sets = m_results->barSets();
 
-    // Move all bar sets from old series to new series
-    for (auto set : sets) {
-        m_results->take(set);
-        results->append(set);
+        // Move all bar sets from old series to new series
+        for (auto set : sets) {
+            m_results->take(set);
+            results->append(set);
+        }
+
+        m_results->deleteLater();
     }
 
-    m_results->deleteLater();
     m_results = results;
     emit resultsChanged(results);
 }

--- a/VotingApp/qml/ContestDetailPage.qml
+++ b/VotingApp/qml/ContestDetailPage.qml
@@ -24,6 +24,13 @@ Page {
 
     signal loaded
     signal closed
+    onClosed: {
+        if (resultsApi)
+            // Schedule the resultsApi for deletion in about 200ms; this page should be gone by then
+            // The delay isn't necessary, but it squelches some warnings in the console
+            resultsApi.destroy(200)
+        contestDetailPage.StackView.view.pop()
+    }
 
     header: ToolBar {
         ToolButton {
@@ -31,7 +38,7 @@ Page {
                 icon: "qrc:/icons/navigation/arrow_back.svg"
                 color: Material.foreground
             }
-            onClicked: contestDetailPage.StackView.view.pop()
+            onClicked: contestDetailPage.closed()
         }
     }
 


### PR DESCRIPTION
Fixed in two different ways!

First was a bug: if the results object on the ContestResultsApi was set
to nullptr, the change was ignored leaving the API holding a dangling
pointer (can we just pretend I'm not the one who wrote that code?)

Second is a minor optimization: go ahead and delete the
ContestResultsApi when the ContestDetailPage is closed rather than
waiting for the garbage collector to find it. This releases server
resources sooner.
