### PR TITLE
Emitting events as object member (this)

### DIFF
--- a/VotingApp/Apis/ContestGeneratorApi.cpp
+++ b/VotingApp/Apis/ContestGeneratorApi.cpp
@@ -43,21 +43,21 @@ QJSValue ContestGeneratorApi::getContests(int count) {
     auto request = generator.getValuesRequest();
     request.setCount(count);
     m_isFetchingContests = true;
-    emit isFetchingContestsChanged(true);
+    emit this->isFetchingContestsChanged(true);
 
     auto pass = [this](auto&& e) {
         m_isFetchingContests = false;
-        emit isFetchingContestsChanged(false);
+        emit this->isFetchingContestsChanged(false);
         return kj::mv(e);
     };
 
     auto contestsPromise = request.send().then([this, count](capnp::Response<ContestGenerator::GetValuesResults> r) {
         if (!r.hasValues() || r.getValues().size() < count) {
             m_isOutOfContests = true;
-            emit isOutOfContestsChanged(true);
+            emit this->isOutOfContestsChanged(true);
         }
         m_isFetchingContests = false;
-        emit isFetchingContestsChanged(false);
+        emit this->isFetchingContestsChanged(false);
         return kj::mv(r);
     }, pass);
 

--- a/VotingApp/Apis/DecisionGeneratorApi.cpp
+++ b/VotingApp/Apis/DecisionGeneratorApi.cpp
@@ -37,22 +37,22 @@ QJSValue DecisionGeneratorApi::getDecisions(int count) {
     auto request = generator.getValuesRequest();
     request.setCount(count);
     m_isFetchingDecisions = true;
-    emit isFetchingDecisionsChanged(true);
+    emit this->isFetchingDecisionsChanged(true);
 
     auto pass = [this](auto&& e) {
         KJ_DBG(e);
         m_isFetchingDecisions = false;
-        emit isFetchingDecisionsChanged(false);
+        emit this->isFetchingDecisionsChanged(false);
         return kj::mv(e);
     };
 
     auto contestsPromise = request.send().then([this, count](capnp::Response<DecisionGenerator::GetValuesResults> r) {
         if (!r.hasValues() || r.getValues().size() < count) {
             m_isOutOfDecisions = true;
-            emit isOutOfDecisionsChanged(true);
+            emit this->isOutOfDecisionsChanged(true);
         }
         m_isFetchingDecisions = false;
-        emit isFetchingDecisionsChanged(false);
+        emit this->isFetchingDecisionsChanged(false);
         return kj::mv(r);
     }, pass);
 


### PR DESCRIPTION
For some strange reason, omitting the `this->` prefix leads to the following error in my environment :

```
error: cannot call member function 'void swv::DecisionGeneratorApi::isFetchingDecisionsChanged(bool)' without object
         emit isFetchingDecisionsChanged(false);
```

My env :
- ArchLinux
- Qt 5.7.0
- Qbs 1.6.0 (qbs profile:qt-5-7-0)
- gcc 6.2.1
