### PR TITLE
Resolve #180: Initial support for contest blacklist

### DIFF
--- a/GrapheneBackend/GrapheneIntegration/BackendPlugin.cpp
+++ b/GrapheneBackend/GrapheneIntegration/BackendPlugin.cpp
@@ -30,6 +30,8 @@
 
 #include <fc/crypto/digest.hpp>
 
+#include <boost/filesystem/path.hpp>
+
 namespace swv {
 
 BackendPlugin::BackendPlugin()
@@ -43,6 +45,7 @@ std::string BackendPlugin::plugin_name() const {
 void BackendPlugin::plugin_initialize(const boost::program_options::variables_map& options) {
     serverPort = options["port"].as<uint16_t>();
     database = kj::heap<VoteDatabase>(*app().chain_database());
+    database->initialize(options["data-dir"].as<boost::filesystem::path>());
     database->registerIndexes();
     KJ_LOG(INFO, "Follow My Vote plugin initialized");
 }

--- a/GrapheneBackend/GrapheneIntegration/CustomEvaluator.cpp
+++ b/GrapheneBackend/GrapheneIntegration/CustomEvaluator.cpp
@@ -20,6 +20,7 @@
 #include "Objects/Contest.hpp"
 #include "Objects/Decision.hpp"
 #include "Objects/CoinVolumeHistory.hpp"
+#include "VoteDatabase.hpp"
 
 #include <datagram.capnp.h>
 #include <decision.capnp.h>
@@ -40,7 +41,8 @@
 
 namespace swv {
 
-void processDecision(gch::database& db, gch::account_id_type publisherId, ::Decision::Reader decision) {
+void processDecision(VoteDatabase& vdb, gch::account_id_type publisherId, ::Decision::Reader decision) {
+    auto& db = vdb.db();
     KJ_REQUIRE(decision.getOpinions().size() <= 1, "Only single-candidate votes are supported", decision);
 
     // Recall that contests are ID'd by their operation history ID, not the object ID
@@ -97,14 +99,29 @@ inline T unpack(capnp::Data::Reader r) {
     return fc::raw::unpack<T>(std::vector<char>(r.begin(), r.end()));
 }
 
-void processContest(gch::database& db, ::Datagram::ContestKey::Creator::Reader key,
+void processContest(VoteDatabase& vdb, ::Datagram::ContestKey::Creator::Reader key,
                     fc::sha256 contestDigest, ::Contest::Reader contest) {
+    auto& db = vdb.db();
+    auto& index = db.get_index_type<gch::simple_index<gch::operation_history_object>>();
+    auto contestId = gch::operation_history_id_type(index.size());
+
+    auto blacklist = vdb.configuration().reader().getContestBlacklist();
+    KJ_DBG("Hey, fuck you! :D");
+    std::for_each(blacklist.begin(), blacklist.end(), [](::ContestId::Reader fuckyou) {KJ_DBG(fuckyou);});
+    auto idItr = std::find_if(blacklist.begin(), blacklist.end(),
+                              [id = contestId.instance.value](::ContestId::Reader r) {
+        return r.getOperationId() == id;
+    });
+    if (idItr != blacklist.end()) {
+        KJ_LOG(DBG, "Ignoring blacklisted contest", contestId.instance.value);
+        return;
+    }
+
     // All relevant data consistency checks should have been done before FMV published the contest to the chain. We
     // should be able to skip them here, relying on the FMV signature to be sure this is a legitimate contest creation
     // request.
-    const auto& contestObject = db.create<Contest>([&db, key, contestDigest, contest](Contest& c) {
-        auto& index = db.get_index_type<gch::simple_index<gch::operation_history_object>>();
-        c.contestId = gch::operation_history_id_type(index.size());
+    const auto& contestObject = db.create<Contest>([&db, key, contestDigest, contest, contestId](Contest& c) {
+        c.contestId = contestId;
         if (key.isSignature()) {
             auto signaturePack = key.getSignature();
             auto id = unpack<gch::account_id_type>(signaturePack.getId());
@@ -132,6 +149,11 @@ inline fc::sha256 digest(capnp::Data::Reader r) {
     return fc::digest(std::vector<char>(r.begin(), r.end()));
 }
 
+kj::Maybe<VoteDatabase&> CustomEvaluator::vdb;
+CustomEvaluator::CustomEvaluator() {
+    KJ_REQUIRE(vdb != nullptr, "Must call CustomEvaluator::setVoteDatabase() before constructing a CustomEvaluator.");
+}
+
 graphene::chain::void_result CustomEvaluator::do_apply(const CustomEvaluator::operation_type& op) {
     try {
         kj::ArrayPtr<const kj::byte> data(reinterpret_cast<const kj::byte*>(op.data.data()), op.data.size());
@@ -155,7 +177,7 @@ graphene::chain::void_result CustomEvaluator::do_apply(const CustomEvaluator::op
                 KJ_REQUIRE(key.getContestId().getOperationId() == content.getContest().getOperationId(),
                            "Decision is not valid: key's contest ID doesn't match decision's contest ID",
                            key.getContestId(), content.getContest());
-                processDecision(db(), op.fee_payer(), content);
+                processDecision(KJ_ASSERT_NONNULL(vdb), op.fee_payer(), content);
                 break;
             }
             case Datagram::DatagramKey::Key::CONTEST_KEY: {
@@ -164,7 +186,7 @@ graphene::chain::void_result CustomEvaluator::do_apply(const CustomEvaluator::op
                 KJ_REQUIRE(kj::StringPtr(op.fee_payer()(db()).name) == CONTEST_PUBLISHING_ACCOUNT,
                            "Unauthorized account attempted to publish contest",
                            op.fee_payer()(db()).name, *CONTEST_PUBLISHING_ACCOUNT);
-                processContest(db(), datagram.getKey().getKey().getContestKey().getCreator(),
+                processContest(KJ_ASSERT_NONNULL(vdb), datagram.getKey().getKey().getContestKey().getCreator(),
                                digest(datagram.getContent()), content);
                 break;
             }

--- a/GrapheneBackend/GrapheneIntegration/CustomEvaluator.hpp
+++ b/GrapheneBackend/GrapheneIntegration/CustomEvaluator.hpp
@@ -21,9 +21,12 @@
 #include <graphene/chain/evaluator.hpp>
 #include <graphene/chain/protocol/custom.hpp>
 
+#include <kj/common.h>
+
 namespace gch = graphene::chain;
 
 namespace swv {
+class VoteDatabase;
 
 /**
  * @brief The CustomEvaluator class implements an evaluator for custom_operation ops, specifically for voting
@@ -34,11 +37,20 @@ namespace swv {
  *
  * The data in a relevant custom_operation is a serialized Datagram. For the operation types and descriptions of their
  * behavior, see datagram.capnp
+ *
+ * @note The CustomEvaluator needs a reference to the VoteDatabase. Set this reference using the static setVoteDatabase
+ * method before constructing any instances of CustomEvaluator
  */
-class CustomEvaluator : public gch::evaluator<CustomEvaluator>
-{
+class CustomEvaluator : public gch::evaluator<CustomEvaluator> {
+    static kj::Maybe<VoteDatabase&> vdb;
 public:
     using operation_type = gch::custom_operation;
+
+    CustomEvaluator();
+
+    static void setVoteDatabase(VoteDatabase& vdb) {
+        CustomEvaluator::vdb = vdb;
+    }
 
     gch::void_result do_evaluate(const operation_type&) { return {}; }
     gch::void_result do_apply(const operation_type& op);

--- a/GrapheneBackend/VoteDatabase.hpp
+++ b/GrapheneBackend/VoteDatabase.hpp
@@ -51,7 +51,6 @@ class VoteDatabase
 {
     gch::database& chain;
     graphene::net::node_ptr p2p_node;
-    CustomEvaluator* _customEvaluator = nullptr;
     gdb::primary_index<ContestIndex>* _contestIndex = nullptr;
     gdb::primary_index<DecisionIndex>* _decisionIndex = nullptr;
     gdb::primary_index<CoinVolumeHistoryIndex>* _coinVolumeHistoryIndex = nullptr;
@@ -73,6 +72,7 @@ class VoteDatabase
 public:
     VoteDatabase(gch::database& chain);
 
+    void initialize(const fc::path& dataDir);
     void registerIndexes();
     void startup(graphene::net::node_ptr node);
 
@@ -89,7 +89,6 @@ public:
         return *p2p_node;
     }
 
-    GETTERS(customEvaluator)
     GETTERS(contestIndex)
     GETTERS(decisionIndex)
     GETTERS(coinVolumeHistoryIndex)

--- a/GrapheneBackend/config.capnp
+++ b/GrapheneBackend/config.capnp
@@ -1,6 +1,7 @@
 @0xc958eba51b7c4b59;
 
 using ContestCreator = import "/contestcreator.capnp".ContestCreator;
+using ContestId = import "/ids.capnp".ContestId;
 using Map = import "/map.capnp".Map;
 
 struct Config {
@@ -12,6 +13,9 @@ struct Config {
     # Private key (WIF format) for the contest publishing account
     authenticatingKeyWif @3 :Text;
     # Private key to authenticate to client with (usually the contest publisher's memo key)
+
+    contestBlacklist @4 :List(ContestId);
+    # List of contest IDs which the server will not track
 
     struct Price {
        lineItem @0 :ContestCreator.LineItems;

--- a/GrapheneBackend/example.cfg
+++ b/GrapheneBackend/example.cfg
@@ -27,7 +27,10 @@ const config :Config = (
                          (name = maxEndDate, limit = 0)
                         ],
                         contestPublishingAccountWif = "5K8GBhm34qWAEhsfEfBcqn5RYjSz1pZ9vkJFa5SsAYjUNEd35b2",
-                        authenticatingKeyWif = "5KXXfu57ZJUeBEf3Kgyxvd5joRYq96VqN9QaS361jq12CHqXUGH"
+                        authenticatingKeyWif = "5KXXfu57ZJUeBEf3Kgyxvd5joRYq96VqN9QaS361jq12CHqXUGH",
+                        contestBlacklist = [
+                         # Example: (operationId = 10)
+                        ]
                        );
 
 

--- a/VotingApp/Converters.hpp
+++ b/VotingApp/Converters.hpp
@@ -68,6 +68,7 @@ public:
           content(message->getRoot<Struct>()) {}
 
     operator capnp::ReaderFor<Struct>() { return content; }
+    capnp::ReaderFor<Struct>& reader() {return content; }
 };
 }
 

--- a/VotingApp/DataStructures/Contest.cpp
+++ b/VotingApp/DataStructures/Contest.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "Contest.hpp"
+#include "Converters.hpp"
 
 #include <QDebug>
 #include <QQmlEngine>
@@ -54,6 +55,10 @@ QString Contest::getCandidateName(int candidateId, Decision* decision) {
     if (candidateId < m_contestants.size())
         return m_contestants[candidateId].toMap()["name"].toString();
     return decision->get_writeIns()[candidateId - m_contestants.size()].toMap()["name"].toString();
+}
+
+QString Contest::simpleId() const {
+    return QString::number(convertSerialStruct<::ContestId>(m_id)->reader().getOperationId());
 }
 
 void Contest::setPendingDecision(Decision* newDecision) {

--- a/VotingApp/DataStructures/Contest.hpp
+++ b/VotingApp/DataStructures/Contest.hpp
@@ -92,6 +92,14 @@ public:
      */
     Q_INVOKABLE QString getCandidateName(int candidateId, swv::data::Decision* decision);
 
+    /**
+     * @brief Get a simplified format of the contest ID
+     *
+     * Instead of a long-form contest ID, such as 100210010108, returns simply 8
+     * @note This may not be applicable on all blockchains, in which case this simply returns the unmodified ID
+     */
+    Q_INVOKABLE QString simpleId() const;
+
 public slots:
     /// @brief Set the pending decision. Destroys the old pending decision and takes ownership of the new one.
     void setPendingDecision(Decision* newDecision);


### PR DESCRIPTION
Add a configuration option to specify a list of contest IDs which should
not be tracked. Currently, changing this list requires replaying the
blockchain.